### PR TITLE
Patrick/further integration

### DIFF
--- a/apps/web/app/components/Dropdown.tsx
+++ b/apps/web/app/components/Dropdown.tsx
@@ -2,8 +2,14 @@
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  CircleIcon,
+} from "lucide-react";
 
+import { textInputVariants } from "~/components/TextInput";
 import { cn } from "~/lib/utils";
 
 function DropdownMenu({
@@ -252,7 +258,105 @@ function DropdownMenuSubContent({
   );
 }
 
+type DropdownOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+type DropdownFieldProps = {
+  label: string;
+  name: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  options: DropdownOption[];
+  id?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  ariaDescribedBy?: string;
+  emptyText?: string;
+  triggerClassName?: string;
+  contentClassName?: string;
+};
+
+function DropdownField({
+  label,
+  name,
+  value,
+  onValueChange,
+  options,
+  id,
+  placeholder = "Select an option...",
+  disabled = false,
+  required = false,
+  ariaDescribedBy,
+  emptyText = "No options available.",
+  triggerClassName,
+  contentClassName,
+}: DropdownFieldProps) {
+  const triggerId = id ?? React.useId();
+  const selectedOption = options.find((option) => option.value === value);
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <label htmlFor={triggerId} className="text-label text-foreground">
+        {label}
+      </label>
+
+      <input type="hidden" name={name} value={value} />
+
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <button
+            id={triggerId}
+            type="button"
+            disabled={disabled}
+            aria-required={required}
+            aria-describedby={ariaDescribedBy}
+            className={cn(
+              textInputVariants({ variant: "form" }),
+              "cursor-pointer justify-between gap-2 pr-4.5 text-left",
+              !selectedOption && "text-accent",
+              disabled && "cursor-not-allowed opacity-50",
+              triggerClassName
+            )}
+          >
+            <span className="min-w-0 flex-1 truncate text-base">
+              {selectedOption?.label ?? placeholder}
+            </span>
+            <ChevronDownIcon className="size-4 shrink-0 text-accent" />
+          </button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent
+          align="start"
+          className={cn("p-1", contentClassName)}
+          style={{ width: "var(--radix-dropdown-menu-trigger-width)" }}
+        >
+          {options.length === 0 ? (
+            <DropdownMenuItem disabled>{emptyText}</DropdownMenuItem>
+          ) : (
+            <DropdownMenuRadioGroup value={value} onValueChange={onValueChange}>
+              {options.map((option) => (
+                <DropdownMenuRadioItem
+                  key={option.value || option.label}
+                  value={option.value}
+                  disabled={option.disabled}
+                >
+                  {option.label}
+                </DropdownMenuRadioItem>
+              ))}
+            </DropdownMenuRadioGroup>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
 export {
+  DropdownField,
   DropdownMenu,
   DropdownMenuPortal,
   DropdownMenuTrigger,
@@ -268,4 +372,5 @@ export {
   DropdownMenuSub,
   DropdownMenuSubTrigger,
   DropdownMenuSubContent,
+  type DropdownOption,
 };

--- a/apps/web/app/components/OverlayDialog.tsx
+++ b/apps/web/app/components/OverlayDialog.tsx
@@ -40,6 +40,7 @@ export function OverlayDialog({
 
         {/* Content (center this directly) */}
         <DialogPrimitive.Content
+          aria-describedby={undefined}
           className={cn(
             "fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2",
             "z-50 outline-none w-[calc(100%-2rem)]",

--- a/apps/web/app/components/TimePickerInput.tsx
+++ b/apps/web/app/components/TimePickerInput.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "~/components/Button";
+import { Icon } from "~/components/Icon";
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/Popover";
+import { TextInput, textInputVariants } from "~/components/TextInput";
+import { cn } from "~/lib/utils";
+import {
+  formatSessionTime,
+  normalizeSessionTime,
+} from "~/lib/session-date-time";
+
+interface TimePickerInputProps {
+  className?: string;
+  id?: string;
+  label: string;
+  value?: string;
+  onChange?: (time: string | undefined) => void;
+}
+
+const TIME_ERROR_MESSAGE = "Enter a valid time, like 2:30 PM or 14:30.";
+
+function parseTimeInput(rawValue: string): string | null {
+  const compactValue = rawValue
+    .trim()
+    .toLowerCase()
+    .replace(/\./g, "")
+    .replace(/\s+/g, "");
+
+  if (!compactValue) {
+    return null;
+  }
+
+  const periodMatch = compactValue.match(/(am|pm|a|p)$/);
+  const period = periodMatch
+    ? periodMatch[1].startsWith("p")
+      ? "PM"
+      : "AM"
+    : null;
+  const valueWithoutPeriod = periodMatch
+    ? compactValue.slice(0, -periodMatch[1].length)
+    : compactValue;
+
+  if (!valueWithoutPeriod) {
+    return null;
+  }
+
+  let hourPart = "";
+  let minutePart = "";
+
+  if (valueWithoutPeriod.includes(":")) {
+    const parts = valueWithoutPeriod.split(":");
+
+    if (
+      parts.length !== 2 ||
+      !/^\d{1,2}$/.test(parts[0]) ||
+      !/^\d{1,2}$/.test(parts[1])
+    ) {
+      return null;
+    }
+
+    [hourPart, minutePart] = parts;
+  } else {
+    if (!/^\d{1,4}$/.test(valueWithoutPeriod)) {
+      return null;
+    }
+
+    if (valueWithoutPeriod.length <= 2) {
+      hourPart = valueWithoutPeriod;
+      minutePart = "00";
+    } else if (valueWithoutPeriod.length === 3) {
+      hourPart = valueWithoutPeriod.slice(0, 1);
+      minutePart = valueWithoutPeriod.slice(1);
+    } else {
+      hourPart = valueWithoutPeriod.slice(0, 2);
+      minutePart = valueWithoutPeriod.slice(2);
+    }
+  }
+
+  const hour = Number(hourPart);
+  const minute = Number(minutePart);
+
+  if (
+    !Number.isInteger(hour) ||
+    !Number.isInteger(minute) ||
+    minute < 0 ||
+    minute > 59
+  ) {
+    return null;
+  }
+
+  if (period) {
+    if (hour < 1 || hour > 12) {
+      return null;
+    }
+
+    const normalizedHour =
+      period === "AM"
+        ? hour === 12
+          ? 0
+          : hour
+        : hour === 12
+          ? 12
+          : hour + 12;
+
+    return `${String(normalizedHour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+  }
+
+  const uses24HourFormat =
+    valueWithoutPeriod.includes(":") ||
+    valueWithoutPeriod.length === 4 ||
+    hour > 12;
+
+  if (!uses24HourFormat || hour < 0 || hour > 23) {
+    return null;
+  }
+
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+function formatEditorValue(sessionTime?: string): string {
+  return sessionTime ? formatSessionTime(sessionTime) : "";
+}
+
+export function TimePickerInput({
+  className,
+  id,
+  label,
+  value,
+  onChange,
+}: TimePickerInputProps) {
+  const [open, setOpen] = React.useState(false);
+  const [error, setError] = React.useState("");
+  const normalizedValue = value ? normalizeSessionTime(value) : undefined;
+  const [draftValue, setDraftValue] = React.useState(() =>
+    formatEditorValue(normalizedValue),
+  );
+  const inputId = id ?? "time";
+
+  React.useEffect(() => {
+    if (!open) {
+      setDraftValue(formatEditorValue(normalizedValue));
+      setError("");
+    }
+  }, [normalizedValue, open]);
+
+  const parsedDraftValue = parseTimeInput(draftValue);
+
+  const commitDraft = (closeOnSuccess = false) => {
+    if (!draftValue.trim()) {
+      onChange?.(undefined);
+      setError("");
+
+      if (closeOnSuccess) {
+        setOpen(false);
+      }
+
+      return true;
+    }
+
+    if (!parsedDraftValue) {
+      setError(TIME_ERROR_MESSAGE);
+      return false;
+    }
+
+    onChange?.(parsedDraftValue);
+    setDraftValue(formatSessionTime(parsedDraftValue));
+    setError("");
+
+    if (closeOnSuccess) {
+      setOpen(false);
+    }
+
+    return true;
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen);
+
+        if (nextOpen) {
+          setDraftValue(formatEditorValue(normalizedValue));
+          setError("");
+          return;
+        }
+
+        setDraftValue(formatEditorValue(normalizedValue));
+        setError("");
+      }}
+    >
+      <div className="flex w-full flex-col gap-2">
+        <label htmlFor={`${inputId}-trigger`} className="text-label text-foreground">
+          {label}
+        </label>
+
+        <PopoverTrigger asChild>
+          <button
+            id={`${inputId}-trigger`}
+            type="button"
+            className={cn(
+              textInputVariants({ variant: "form" }),
+              "cursor-pointer pr-0 text-left focus-visible:shadow-focus",
+              className,
+            )}
+            onKeyDown={(event) => {
+              if (event.key === "ArrowDown") {
+                event.preventDefault();
+                setOpen(true);
+              }
+            }}
+          >
+            <span
+              className={cn(
+                "flex-1 text-base",
+                normalizedValue ? "text-foreground" : "text-accent",
+              )}
+            >
+              {normalizedValue ? formatSessionTime(normalizedValue) : "Choose time"}
+            </span>
+
+            <span className="flex h-full items-center pr-2.5 text-accent">
+              <Icon name="Clock3" className="size-3.5" />
+            </span>
+          </button>
+        </PopoverTrigger>
+      </div>
+
+      <PopoverContent className="w-80 space-y-4" align="start" sideOffset={10}>
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <p className="text-xs text-foreground">
+              Type a time with AM/PM, or use 24-hour time.
+            </p>
+            <p className="text-sm text-foreground">
+              {parsedDraftValue
+                ? formatSessionTime(parsedDraftValue)
+                : normalizedValue
+                  ? formatSessionTime(normalizedValue)
+                  : "No time selected"}
+            </p>
+          </div>
+
+          {normalizedValue ? (
+            <Button
+              type="button"
+              variant="link"
+              size="none"
+              className="text-xs text-foreground hover:text-foreground"
+              onClick={() => {
+                setDraftValue("");
+                onChange?.(undefined);
+                setError("");
+                setOpen(false);
+              }}
+            >
+              Clear
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          <TextInput
+            id={`${inputId}-editor`}
+            label="Time"
+            value={draftValue}
+            variant="form"
+            placeholder="Enter time, like 2:30 PM"
+            autoComplete="off"
+            autoCapitalize="characters"
+            spellCheck={false}
+            onChange={(event) => {
+              const nextValue = event.target.value;
+              setDraftValue(nextValue);
+
+              if (!nextValue.trim()) {
+                onChange?.(undefined);
+                setError("");
+                return;
+              }
+
+              const parsedValue = parseTimeInput(nextValue);
+
+              if (parsedValue) {
+                onChange?.(parsedValue);
+                setError("");
+              } else if (error) {
+                setError("");
+              }
+            }}
+            onBlur={() => {
+              if (!draftValue.trim()) {
+                setError("");
+                return;
+              }
+
+              if (parsedDraftValue) {
+                setDraftValue(formatSessionTime(parsedDraftValue));
+                setError("");
+                return;
+              }
+
+              setError(TIME_ERROR_MESSAGE);
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                commitDraft(true);
+              }
+            }}
+          />
+
+          <p className="text-xs text-foreground">
+            Examples: 2:30 PM, 230p, or 14:30.
+          </p>
+
+          {error ? (
+            <p
+              className="text-[13px] leading-snug text-destructive/90"
+              role="alert"
+            >
+              {error}
+            </p>
+          ) : null}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/app/components/layout/SessionHeader.tsx
+++ b/apps/web/app/components/layout/SessionHeader.tsx
@@ -1,5 +1,6 @@
 import { Button } from "~/components/Button";
 import { Icon } from "~/components/Icon";
+import { formatSessionTime } from "~/lib/session-date-time";
 import { useSessionStore } from "~/stores/useSessionStore";
 
 const HEADER_ITEM_CLASS = "px-4 whitespace-nowrap";
@@ -38,7 +39,14 @@ export function SessionHeader() {
 
         <div className="flex items-center gap-3">
           {activeSession?.date ? (
-            <span className={HEADER_ITEM_CLASS}>{activeSession.date}</span>
+            <div className="flex items-center gap-3">
+              <span className={HEADER_ITEM_CLASS}>{activeSession.date}</span>
+              {activeSession.time ? (
+                <span className={`${HEADER_ITEM_CLASS} text-foreground`}>
+                  {formatSessionTime(activeSession.time)}
+                </span>
+              ) : null}
+            </div>
           ) : null}
           <Button
             variant="ghost"

--- a/apps/web/app/components/session/analysis/chapters/ChapterCard.tsx
+++ b/apps/web/app/components/session/analysis/chapters/ChapterCard.tsx
@@ -1,6 +1,7 @@
 // app/components/session/analysis/chapters/ChapterCard.tsx
 
 import { memo, useRef } from "react";
+import { Loader2 } from "lucide-react";
 import { TextArea } from "~/components/TextArea";
 import { Button } from "~/components/Button";
 import { TimeInput } from "../../common/TimeInput";
@@ -11,6 +12,9 @@ import { cn } from "~/lib/utils";
 import { validateTimeBoundary } from "~/lib/timeline-calculations";
 import type { Chapter } from "~/data/mock-session-data";
 import { useVideoStore } from "~/stores/useVideoStore";
+import { selectActiveView, useSessionStore } from "~/stores/useSessionStore";
+import { useChapterStore } from "~/stores/useChapterStore";
+import { useChapterThumbnail } from "./useChapterThumbnail";
 
 interface ChapterCardProps {
   data: Chapter;
@@ -33,6 +37,14 @@ export const ChapterCard = memo(
     const cardRef = useRef<HTMLDivElement>(null);
     const videoDuration = useVideoStore((state) => state.duration);
     const seekTo = useVideoStore((state) => state.actions.seekTo);
+    const videoId = useChapterStore((state) => state.videoId);
+    const activeView = useSessionStore(selectActiveView);
+    const { thumbnailUrl, isLoading } = useChapterThumbnail({
+      videoId,
+      timestamp: data.timestamp,
+      fallbackUrl: data.thumbnailUrl,
+      enabled: Boolean(videoId && !activeView?.uploading && !activeView?.uploadError),
+    });
 
     useAutoDeselect(cardRef, isSelected, onDeselect);
 
@@ -71,14 +83,20 @@ export const ChapterCard = memo(
         className="gap-y-4.5"
       >
         {/* Thumbnail (and settings) */}
-        <div className="flex items-start justify-between">
-          {data.thumbnailUrl && (
+        <div className="flex items-start justify-between gap-3">
+          <div className="relative w-full max-w-60 min-w-0 overflow-hidden rounded-sm">
             <img
-              src={data.thumbnailUrl}
+              src={thumbnailUrl}
               alt={data.title || "Chapter thumbnail"}
-              className="rounded-sm object-cover aspect-video w-full max-w-60 min-w-0"
+              className="aspect-video w-full object-cover"
             />
-          )}
+
+            {isLoading ? (
+              <div className="absolute inset-0 flex items-center justify-center bg-background/55">
+                <Loader2 className="size-4 animate-spin text-foreground" />
+              </div>
+            ) : null}
+          </div>
 
           <AnalysisCardSettings onDelete={onDelete} />
         </div>

--- a/apps/web/app/components/session/analysis/chapters/ChapterContent.tsx
+++ b/apps/web/app/components/session/analysis/chapters/ChapterContent.tsx
@@ -1,14 +1,17 @@
+import { ListTree, Loader2 } from "lucide-react";
 import { Button } from "~/components/Button";
 import { Icon } from "~/components/Icon";
+import { ChapterEmptyState } from "./ChapterEmptyState";
 import { ChapterList } from "./ChapterList";
 import { useChapterStore } from "~/stores/useChapterStore";
+import { selectActiveView, useSessionStore } from "~/stores/useSessionStore";
 import {
   PanelScrollArea,
   PanelSection,
   PanelSectionBody,
   PanelSectionHeader,
 } from "../../common/PanelSection";
-
+import { ProcessingNotice } from "../../common/ProcessingNotice";
 /**
  * Tab content for the Chapters section in the Analysis Panel.
  * Displays a button to create new chapters and lists existing chapters.
@@ -17,6 +20,19 @@ export function ChapterContent() {
   const handleNewChapter = useChapterStore(
     (state) => state.actions.handleNewChapter,
   );
+  const chapters = useChapterStore((state) => state.chapters);
+  const taskStatus = useChapterStore((state) => state.taskStatus);
+  const activeView = useSessionStore(selectActiveView);
+
+  const hasActiveView = Boolean(activeView);
+  const hasChapters = chapters.length > 0;
+  const isGenerating =
+    activeView?.uploading ||
+    taskStatus === "pending" ||
+    taskStatus === "processing";
+  const showGeneratingNotice = hasChapters && isGenerating;
+  const showGeneratingEmptyState = hasActiveView && !hasChapters && isGenerating;
+  const showEmptyState = hasActiveView && !hasChapters && !isGenerating;
 
   return (
     <PanelSection>
@@ -29,7 +45,30 @@ export function ChapterContent() {
 
       <PanelSectionBody>
         <PanelScrollArea>
-          <ChapterList />
+          <div className="flex min-h-full flex-col gap-3">
+            {showGeneratingNotice ? (
+              <ProcessingNotice>
+                You can still add chapters while more are generated.
+              </ProcessingNotice>
+            ) : null}
+
+            {showGeneratingEmptyState ? (
+              <ChapterEmptyState
+                role="status"
+                icon={<Loader2 className="size-4 animate-spin text-foreground" />}
+                title="Automatic chapters are generating"
+                description="You can still add your own while they finish."
+              />
+            ) : showEmptyState ? (
+              <ChapterEmptyState
+                icon={<ListTree className="size-4 text-foreground" />}
+                title="No chapters yet"
+                description="Add one to get started."
+              />
+            ) : (
+              <ChapterList />
+            )}
+          </div>
         </PanelScrollArea>
       </PanelSectionBody>
     </PanelSection>

--- a/apps/web/app/components/session/analysis/chapters/ChapterEmptyState.tsx
+++ b/apps/web/app/components/session/analysis/chapters/ChapterEmptyState.tsx
@@ -1,0 +1,30 @@
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "~/lib/utils";
+
+interface ChapterEmptyStateProps extends ComponentProps<"div"> {
+  icon: ReactNode;
+  title: string;
+  description: string;
+}
+
+export function ChapterEmptyState({
+  icon,
+  title,
+  description,
+  className,
+  ...props
+}: ChapterEmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-48 flex-1 flex-col items-center justify-center gap-2 text-center",
+        className,
+      )}
+      {...props}
+    >
+      {icon}
+      <p className="text-sm text-foreground">{title}</p>
+      <p className="max-w-60 text-xs text-foreground">{description}</p>
+    </div>
+  );
+}

--- a/apps/web/app/components/session/analysis/chapters/useChapterThumbnail.ts
+++ b/apps/web/app/components/session/analysis/chapters/useChapterThumbnail.ts
@@ -1,0 +1,88 @@
+import * as React from "react";
+import { videoService } from "~/services/videos";
+
+interface UseChapterThumbnailOptions {
+  videoId?: string | null;
+  timestamp: number;
+  fallbackUrl: string;
+  enabled?: boolean;
+}
+
+export function useChapterThumbnail({
+  videoId,
+  timestamp,
+  fallbackUrl,
+  enabled = true,
+}: UseChapterThumbnailOptions) {
+  const objectUrlRef = React.useRef<string | null>(null);
+  const [thumbnailUrl, setThumbnailUrl] = React.useState(fallbackUrl);
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!objectUrlRef.current) {
+      setThumbnailUrl(fallbackUrl);
+    }
+  }, [fallbackUrl]);
+
+  React.useEffect(() => {
+    if (!videoId || !enabled || !Number.isFinite(timestamp) || timestamp < 0) {
+      setIsLoading(false);
+      if (!objectUrlRef.current) {
+        setThumbnailUrl(fallbackUrl);
+      }
+      return;
+    }
+
+    const abortController = new AbortController();
+    setIsLoading(true);
+
+    void videoService
+      .getThumbnail(videoId, timestamp, abortController.signal)
+      .then((blob) => {
+        if (abortController.signal.aborted) {
+          return;
+        }
+
+        const nextObjectUrl = URL.createObjectURL(blob);
+        const previousObjectUrl = objectUrlRef.current;
+
+        objectUrlRef.current = nextObjectUrl;
+        setThumbnailUrl(nextObjectUrl);
+        setIsLoading(false);
+
+        if (previousObjectUrl) {
+          URL.revokeObjectURL(previousObjectUrl);
+        }
+      })
+      .catch((error) => {
+        if (abortController.signal.aborted) {
+          return;
+        }
+
+        console.error("Failed to load chapter thumbnail:", error);
+        setIsLoading(false);
+
+        if (!objectUrlRef.current) {
+          setThumbnailUrl(fallbackUrl);
+        }
+      });
+
+    return () => {
+      abortController.abort();
+    };
+  }, [enabled, fallbackUrl, timestamp, videoId]);
+
+  React.useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  return {
+    thumbnailUrl,
+    isLoading,
+  };
+}

--- a/apps/web/app/components/session/analysis/points/PointsContent.tsx
+++ b/apps/web/app/components/session/analysis/points/PointsContent.tsx
@@ -5,13 +5,15 @@ import {
   selectAllPointsVisible,
   usePointStore,
 } from "~/stores/usePointsStore";
+import { useKeypointStore } from "~/stores/useKeypointStore";
+import { selectActiveView, useSessionStore } from "~/stores/useSessionStore";
 import {
   PanelScrollArea,
   PanelSection,
   PanelSectionBody,
   PanelSectionHeader,
 } from "../../common/PanelSection";
-
+import { ProcessingNotice } from "../../common/ProcessingNotice";
 /**
  * Tab content for the Points section in the Analysis Panel.
  *
@@ -20,9 +22,18 @@ import {
  */
 export function PointsContent() {
   const allPointsVisible = usePointStore(selectAllPointsVisible);
+  const points = usePointStore((state) => state.points);
   const toggleAllVisibility = usePointStore(
     (state) => state.actions.toggleAllVisibility,
   );
+  const poseStatus = useKeypointStore((state) => state.poseStatus);
+  const activeView = useSessionStore(selectActiveView);
+
+  const showProcessingHint =
+    Boolean(activeView?.videoId) &&
+    !activeView?.uploading &&
+    points.length > 0 &&
+    (poseStatus === "pending" || poseStatus === "processing");
 
   return (
     <PanelSection>
@@ -35,7 +46,12 @@ export function PointsContent() {
 
       <PanelSectionBody>
         <PanelScrollArea>
-          <PointList />
+          <div className="flex flex-col gap-3">
+            {showProcessingHint ? (
+              <ProcessingNotice>Overlay data is still updating.</ProcessingNotice>
+            ) : null}
+            <PointList />
+          </div>
         </PanelScrollArea>
       </PanelSectionBody>
     </PanelSection>

--- a/apps/web/app/components/session/common/PipelineProgress.tsx
+++ b/apps/web/app/components/session/common/PipelineProgress.tsx
@@ -1,3 +1,4 @@
+import { AlertCircle, Loader2 } from "lucide-react";
 import { cn } from "~/lib/utils";
 
 export type StepStatus = "pending" | "active" | "completed" | "failed";
@@ -10,54 +11,62 @@ interface Step {
 interface PipelineProgressProps {
   steps: Step[];
   className?: string;
+  playbackReady?: boolean;
+  overlaysReady?: boolean;
 }
 
-/**
- * A minimal text-based progress indicator that shows the current pipeline step.
- * Displays "Step X/N - label..." with a pulsing animation.
- */
+function getStatusMessage(
+  steps: Step[],
+  playbackReady: boolean,
+  overlaysReady: boolean,
+) {
+  const failedStep = steps.find((step) => step.status === "failed");
+  if (failedStep) {
+    return "Processing failed";
+  }
+
+  const chapterStep = steps[2];
+  const chaptersReady = chapterStep?.status === "completed";
+
+  if (!playbackReady) {
+    return "Uploading";
+  }
+
+  if (overlaysReady && !chaptersReady) {
+    return "Generating chapters";
+  }
+
+  if (!overlaysReady) {
+    return "Analyzing";
+  }
+
+  return "Processing";
+}
+
 export function PipelineProgress({
   steps,
   className,
+  playbackReady = false,
+  overlaysReady = false,
 }: PipelineProgressProps) {
-  const activeIndex = steps.findIndex((step) => step.status === "active");
-  const pendingIndex =
-    activeIndex === -1
-      ? steps.findIndex((step) => step.status === "pending")
-      : -1;
   const failedIndex = steps.findIndex((step) => step.status === "failed");
-
-  if (failedIndex !== -1) {
-    const step = steps[failedIndex];
-    return (
-      <span
-        className={cn(
-          "inline-flex items-center gap-1.5 text-xs text-foreground",
-          className,
-        )}
-      >
-        <span>
-          Step {failedIndex + 1}/{steps.length} - {step.label} failed
-        </span>
-      </span>
-    );
-  }
-
-  const visibleIndex = activeIndex !== -1 ? activeIndex : pendingIndex;
-  if (visibleIndex === -1) return null;
-
-  const step = steps[visibleIndex];
+  const label = getStatusMessage(steps, playbackReady, overlaysReady);
 
   return (
     <span
+      role="status"
+      aria-live="polite"
       className={cn(
-        "inline-flex items-center gap-1.5 text-xs text-muted-foreground",
+        "inline-flex min-w-0 items-center gap-1.5 text-label text-foreground",
         className,
       )}
     >
-      <span className="animate-pulse">
-        Step {visibleIndex + 1}/{steps.length} - {step.label}
-      </span>
+      {failedIndex !== -1 ? (
+        <AlertCircle className="size-3.5 shrink-0 text-destructive" />
+      ) : (
+        <Loader2 className="size-3.5 shrink-0 animate-spin" />
+      )}
+      <span className={cn(failedIndex !== -1 && "text-destructive")}>{label}</span>
     </span>
   );
 }

--- a/apps/web/app/components/session/common/ProcessingNotice.tsx
+++ b/apps/web/app/components/session/common/ProcessingNotice.tsx
@@ -1,0 +1,25 @@
+import type { ComponentProps } from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "~/lib/utils";
+
+interface ProcessingNoticeProps extends ComponentProps<"p"> {}
+
+export function ProcessingNotice({
+  children,
+  className,
+  ...props
+}: ProcessingNoticeProps) {
+  return (
+    <p
+      role="status"
+      className={cn(
+        "inline-flex items-center gap-2 text-xs text-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <Loader2 className="size-3.5 shrink-0 animate-spin" />
+      <span>{children}</span>
+    </p>
+  );
+}

--- a/apps/web/app/components/session/directory/DirectoryPanel.tsx
+++ b/apps/web/app/components/session/directory/DirectoryPanel.tsx
@@ -7,6 +7,7 @@ import { TextInput } from "~/components/TextInput";
 import { useSessionStore } from "~/stores/useSessionStore";
 import { SessionList } from "~/components/session/directory/SessionList";
 import { NewSessionDialog } from "~/components/session/directory/NewSessionDialog";
+import { formatSessionTime } from "~/lib/session-date-time";
 import {
   PanelScrollArea,
   PanelSection,
@@ -27,9 +28,18 @@ export function DirectoryPanel() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
-  const filteredSessions = sessions.filter((s) =>
-    s.date.toLowerCase().includes(searchQuery.toLowerCase()),
-  );
+  const normalizedQuery = searchQuery.toLowerCase();
+  const filteredSessions = sessions.filter((session) => {
+    const searchText = [
+      session.date,
+      formatSessionTime(session.time),
+      session.time ?? "",
+    ]
+      .join(" ")
+      .toLowerCase();
+
+    return searchText.includes(normalizedQuery);
+  });
 
   return (
     <PanelSection className="p-4.5">

--- a/apps/web/app/components/session/directory/NewSessionDialog.tsx
+++ b/apps/web/app/components/session/directory/NewSessionDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { DatePickerInput } from "~/components/DatePickerInput";
+import { TimePickerInput } from "~/components/TimePickerInput";
 import { TextInput } from "~/components/TextInput";
 import { MediaUploadDialog } from "~/components/session/common/MediaUploadDialog";
 import { useSessionStore } from "~/stores/useSessionStore";
@@ -18,11 +19,16 @@ export function NewSessionDialog({
   const addSession = useSessionStore((state) => state.actions.addSession);
   const [patientId, setPatientId] = useState("");
   const [date, setDate] = useState<Date | undefined>(undefined);
-  const sessionDetailsReady = patientId.trim().length > 0 && date !== undefined;
+  const [time, setTime] = useState<string | undefined>(undefined);
+  const sessionDetailsReady =
+    patientId.trim().length > 0 &&
+    date !== undefined &&
+    Boolean(time);
 
   const resetDialog = () => {
     setPatientId("");
     setDate(undefined);
+    setTime(undefined);
   };
 
   return (
@@ -54,15 +60,28 @@ export function NewSessionDialog({
             autoFocus
           />
 
-          <DatePickerInput
-            label="Session Date"
-            value={date}
-            onChange={(nextDate) => {
-              clearError();
-              setDate(nextDate);
-            }}
-            className="w-full"
-          />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <DatePickerInput
+              label="Session Date"
+              value={date}
+              onChange={(nextDate) => {
+                clearError();
+                setDate(nextDate);
+              }}
+              className="w-full"
+            />
+
+            <TimePickerInput
+              id="session-time"
+              label="Session Time"
+              value={time}
+              onChange={(nextTime) => {
+                clearError();
+                setTime(nextTime);
+              }}
+              className="w-full"
+            />
+          </div>
         </>
       )}
       onSubmit={async (drafts) => {
@@ -70,9 +89,14 @@ export function NewSessionDialog({
           throw new Error("Session date is required.");
         }
 
+        if (!time) {
+          throw new Error("Session time is required.");
+        }
+
         await addSession({
           patientId: patientId.trim(),
           date,
+          time,
           media: drafts.map((draft) => ({
             title: draft.title.trim(),
             file: draft.media.file,

--- a/apps/web/app/components/session/directory/SessionCard.tsx
+++ b/apps/web/app/components/session/directory/SessionCard.tsx
@@ -1,10 +1,13 @@
 import { Icon } from "~/components/Icon";
 import { Button } from "~/components/Button";
+import { formatSessionTime } from "~/lib/session-date-time";
 import { cn } from "~/lib/utils";
 
 interface SessionCardProps {
   /* Display date for the session (e.g. "08/15/2024") */
   date: string;
+  /* Raw session time for the card (e.g. "14:30") */
+  time?: string;
   /* Whether this session is currently active (selected) */
   isActive: boolean;
   /* Whether this session has an unread notification (e.g. new data since last viewed) */
@@ -25,6 +28,7 @@ interface SessionCardProps {
  */
 export function SessionCard({
   date,
+  time,
   isActive,
   hasNotification,
   onClick,
@@ -44,11 +48,18 @@ export function SessionCard({
     >
       <div className="flex items-center gap-3">
         <Icon name="FilePlay" strokeWidth={hasNotification ? 2 : 1} />
-        <span
-          className={cn("text-headline", !hasNotification && "font-normal")}
-        >
-          {date}
-        </span>
+        <div className="flex flex-col items-start">
+          <span
+            className={cn("text-headline", !hasNotification && "font-normal")}
+          >
+            {date}
+          </span>
+          {time ? (
+            <span className="text-xs text-foreground">
+              {formatSessionTime(time)}
+            </span>
+          ) : null}
+        </div>
       </div>
 
       {hasNotification && (

--- a/apps/web/app/components/session/directory/SessionList.tsx
+++ b/apps/web/app/components/session/directory/SessionList.tsx
@@ -41,6 +41,7 @@ export function SessionList({
         <SessionCard
           key={session.id}
           date={session.date}
+          time={session.time}
           isActive={activeSessionId === session.id}
           hasNotification={session.notification}
           onClick={() => handleSelection(session)}

--- a/apps/web/app/components/session/player/video/VideoStage.tsx
+++ b/apps/web/app/components/session/player/video/VideoStage.tsx
@@ -32,6 +32,8 @@ export function VideoStage({ activeView }: VideoStageProps) {
 
   const hasActiveView = Boolean(activeView);
   const hasPlaybackUrl = Boolean(playbackUrl);
+  const overlayControlsReady =
+    Boolean(activeView?.videoId) && hasPlaybackUrl && frames.length > 0;
 
   const handleVideoClick = useCallback(() => {
     const nextPlaying = !isPlaying;
@@ -44,8 +46,14 @@ export function VideoStage({ activeView }: VideoStageProps) {
   return (
     <section className="flex flex-col gap-y-3">
       <div className="flex items-center justify-between gap-4">
-        <VideoStageToggles />
-        {pipelineVisible && <PipelineProgress steps={pipelineSteps} />}
+        <VideoStageToggles disabled={!overlayControlsReady} />
+        {pipelineVisible && (
+          <PipelineProgress
+            steps={pipelineSteps}
+            playbackReady={hasPlaybackUrl}
+            overlaysReady={overlayControlsReady}
+          />
+        )}
       </div>
 
       <div className="relative aspect-video w-full overflow-hidden rounded-3xl bg-black">

--- a/apps/web/app/components/session/player/video/VideoStageToggles.tsx
+++ b/apps/web/app/components/session/player/video/VideoStageToggles.tsx
@@ -8,7 +8,13 @@ const STAGE_TOGGLES: Array<{ key: StageOverlayKey; label: string }> = [
   { key: "points", label: "Points" },
 ];
 
-export function VideoStageToggles() {
+interface VideoStageTogglesProps {
+  disabled?: boolean;
+}
+
+export function VideoStageToggles({
+  disabled = false,
+}: VideoStageTogglesProps) {
   const enabledOverlays = useOverlayStore((s) => s.enabledOverlays);
   const toggleOverlay = useOverlayStore((s) => s.actions.toggleOverlay);
 
@@ -19,6 +25,12 @@ export function VideoStageToggles() {
           key={toggle.key}
           pressed={enabledOverlays[toggle.key]}
           onPressedChange={() => toggleOverlay(toggle.key)}
+          disabled={disabled}
+          title={
+            disabled
+              ? "Overlays unlock automatically once pose data is ready."
+              : undefined
+          }
           className="text-foreground inset-ring-2 inset-ring-accent"
         >
           {toggle.label}

--- a/apps/web/app/components/ui/dialog.tsx
+++ b/apps/web/app/components/ui/dialog.tsx
@@ -50,6 +50,7 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  "aria-describedby": ariaDescribedBy,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
@@ -59,6 +60,7 @@ function DialogContent({
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
+        aria-describedby={ariaDescribedBy}
         className={cn(
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className

--- a/apps/web/app/data/mock-session-data.ts
+++ b/apps/web/app/data/mock-session-data.ts
@@ -63,6 +63,7 @@ export type Session = {
   patientId?: string;
   patientUuid?: string;
   date: string;
+  time?: string;
   notification: boolean;
   views: View[];
 };

--- a/apps/web/app/hooks/useKeypointSync.ts
+++ b/apps/web/app/hooks/useKeypointSync.ts
@@ -21,8 +21,11 @@ const PLAYHEAD_PREFETCH_WINDOW_SEC = 2.5;
 /** Minimum spacing between incremental `since` refreshes (ms). */
 const MIN_FETCH_GAP_MS = 750;
 
-/** Back off briefly after an empty `since` response while still processing (ms). */
-const EMPTY_RESULT_COOLDOWN_MS = 1_500;
+/** Back off after an empty or tiny incremental batch while pose streaming is still in flight (ms). */
+const STREAMING_BATCH_COOLDOWN_MS = 2_250;
+
+/** Minimum timestamp coverage gain that counts as a meaningful incremental batch while streaming (sec). */
+const MIN_STREAMING_BATCH_COVERAGE_SEC = 2;
 
 function normalizePoseStatus(raw: ReturnType<typeof getWorkerStepStatus>): PoseStatus {
   switch (raw) {
@@ -77,7 +80,7 @@ export function useKeypointSync(videoId: string | undefined) {
   const pendingTargetTimestampRef = useRef<number | null>(null);
   const pendingForceRef = useRef(false);
   const lastSinceRequestAtRef = useRef(0);
-  const emptyCooldownUntilRef = useRef(0);
+  const fetchCooldownUntilRef = useRef(0);
 
   const stopPolling = useCallback(() => {
     if (pollTimerRef.current) {
@@ -116,7 +119,7 @@ export function useKeypointSync(videoId: string | undefined) {
           return false;
         }
 
-        if (now < emptyCooldownUntilRef.current) {
+        if (now < fetchCooldownUntilRef.current) {
           return false;
         }
       }
@@ -141,7 +144,8 @@ export function useKeypointSync(videoId: string | undefined) {
 
           if (rows.length === 0) {
             if (!receivedAny) {
-              emptyCooldownUntilRef.current = Date.now() + EMPTY_RESULT_COOLDOWN_MS;
+              fetchCooldownUntilRef.current =
+                Date.now() + STREAMING_BATCH_COOLDOWN_MS;
             }
             pendingDrainToEmptyRef.current = false;
             pendingTargetTimestampRef.current = null;
@@ -158,9 +162,26 @@ export function useKeypointSync(videoId: string | undefined) {
             break;
           }
 
+          const coverageGainSec = Math.max(
+            0,
+            lastRow.timestamp - cursorTimestamp,
+          );
+
           mergeRows(rows, { advanceCursor: true });
           receivedAny = true;
-          emptyCooldownUntilRef.current = 0;
+          fetchCooldownUntilRef.current = 0;
+
+          if (
+            isPoseStreaming(lastPoseStatusRef.current) &&
+            coverageGainSec < MIN_STREAMING_BATCH_COVERAGE_SEC
+          ) {
+            fetchCooldownUntilRef.current =
+              Date.now() + STREAMING_BATCH_COOLDOWN_MS;
+            pendingDrainToEmptyRef.current = false;
+            pendingTargetTimestampRef.current = null;
+            pendingForceRef.current = false;
+            break;
+          }
 
           await delay(PAGE_DELAY_MS);
         }
@@ -243,7 +264,7 @@ export function useKeypointSync(videoId: string | undefined) {
     pendingForceRef.current = false;
     activeSyncPromiseRef.current = null;
     lastSinceRequestAtRef.current = 0;
-    emptyCooldownUntilRef.current = 0;
+    fetchCooldownUntilRef.current = 0;
 
     const abort = new AbortController();
     abortRef.current = abort;
@@ -268,7 +289,7 @@ export function useKeypointSync(videoId: string | undefined) {
       pendingForceRef.current = false;
       activeSyncPromiseRef.current = null;
       lastSinceRequestAtRef.current = 0;
-      emptyCooldownUntilRef.current = 0;
+      fetchCooldownUntilRef.current = 0;
     };
   }, [reset, startPolling, stopPolling, syncSince, videoId]);
 

--- a/apps/web/app/lib/session-date-time.ts
+++ b/apps/web/app/lib/session-date-time.ts
@@ -1,0 +1,64 @@
+export function formatSessionDate(isoDate: string): string {
+  const [year, month, day] = isoDate.split("-");
+  return `${month}/${day}/${year}`;
+}
+
+export function normalizeSessionTime(sessionTime: string): string {
+  const trimmed = sessionTime.trim();
+  const match = trimmed.match(/^(\d{2}):(\d{2})(?::\d{2})?$/);
+
+  if (!match) {
+    return trimmed;
+  }
+
+  return `${match[1]}:${match[2]}`;
+}
+
+export function formatSessionTime(sessionTime?: string): string {
+  if (!sessionTime) {
+    return "";
+  }
+
+  const normalized = normalizeSessionTime(sessionTime);
+  const match = normalized.match(/^(\d{2}):(\d{2})$/);
+
+  if (!match) {
+    return normalized;
+  }
+
+  const hours = Number(match[1]);
+  const minutes = match[2];
+  const suffix = hours >= 12 ? "PM" : "AM";
+  const hour12 = hours % 12 || 12;
+
+  return `${hour12}:${minutes} ${suffix}`;
+}
+
+export function parseDisplaySessionDateTime(
+  date: string,
+  sessionTime?: string,
+): number {
+  const [month = "", day = "", year = ""] = date.split("/");
+  const monthNumber = Number.parseInt(month, 10);
+  const dayNumber = Number.parseInt(day, 10);
+  const yearNumber = Number.parseInt(year, 10);
+  const normalizedTime = normalizeSessionTime(sessionTime ?? "00:00");
+  const timeMatch = normalizedTime.match(/^(\d{2}):(\d{2})$/);
+
+  if (
+    !Number.isFinite(monthNumber) ||
+    !Number.isFinite(dayNumber) ||
+    !Number.isFinite(yearNumber) ||
+    !timeMatch
+  ) {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  return Date.UTC(
+    yearNumber,
+    monthNumber - 1,
+    dayNumber,
+    Number(timeMatch[1]),
+    Number(timeMatch[2]),
+  );
+}

--- a/apps/web/app/lib/session-directory-sorting.ts
+++ b/apps/web/app/lib/session-directory-sorting.ts
@@ -1,21 +1,5 @@
 import type { Session } from "~/data/mock-session-data";
-
-function parseDisplayDate(date: string): number {
-  const [month = "", day = "", year = ""] = date.split("/");
-  const monthNumber = Number.parseInt(month, 10);
-  const dayNumber = Number.parseInt(day, 10);
-  const yearNumber = Number.parseInt(year, 10);
-
-  if (
-    !Number.isFinite(monthNumber) ||
-    !Number.isFinite(dayNumber) ||
-    !Number.isFinite(yearNumber)
-  ) {
-    return Number.NEGATIVE_INFINITY;
-  }
-
-  return Date.UTC(yearNumber, monthNumber - 1, dayNumber);
-}
+import { parseDisplaySessionDateTime } from "~/lib/session-date-time";
 
 export function sortSessionsForDirectory(
   sessions: readonly Session[],
@@ -25,10 +9,10 @@ export function sortSessionsForDirectory(
       return a.notification ? -1 : 1;
     }
 
-    const aDate = parseDisplayDate(a.date);
-    const bDate = parseDisplayDate(b.date);
-    if (aDate !== bDate) {
-      return bDate - aDate;
+    const aDateTime = parseDisplaySessionDateTime(a.date, a.time);
+    const bDateTime = parseDisplaySessionDateTime(b.date, b.time);
+    if (aDateTime !== bDateTime) {
+      return bDateTime - aDateTime;
     }
 
     return b.id.localeCompare(a.id);

--- a/apps/web/app/routes/home.tsx
+++ b/apps/web/app/routes/home.tsx
@@ -1,37 +1,25 @@
-import { Card } from "~/components/Card";
 import { Icon } from "~/components/Icon";
 import type { Route } from "./+types/home";
 
 export function meta({}: Route.MetaArgs) {
   return [
     { title: "Home" },
-    { name: "description", content: "insert description" },
+    {
+      name: "description",
+      content: "Nothing in the home page for now, navigate to the sessions page.",
+    },
   ];
 }
 
 export default function Home() {
   return (
-    <main>
-      <section>
-        <div className="font-bold">Bold</div>
-        <div className="font-semibold">Semibold</div>
-        <div className="font-normal">Regular</div>
-        <div className="font-light">Light</div>
-      </section>
-      <Card>
-        <p className="text-display">Display</p>
-        <p className="text-title-1">Title 1</p>
-        <p className="text-title-2">Title 2</p>
-        <p className="text-title-3">Title 3</p>
-        <p className="text-headline font-semibold">Headline</p>
-        <p className="text-base">Base</p>
-        <p className="text-subhead">Subhead</p>
-        <p className="text-label">Label</p>
-      </Card>
-      <section>
-        <Icon name="House" size="primary" />
-        <Icon name="Settings" size="secondary" />
-      </section>
+    <main className="flex h-full items-center justify-center p-6">
+      <div className="flex flex-col items-center gap-3 text-center">
+        <Icon name="HousePlug" className="size-10" />
+        <p className="text-center text-title-3">
+          Nothing in the home page for now, navigate to the sessions page.
+        </p>
+      </div>
     </main>
   );
 }

--- a/apps/web/app/routes/joinorgapp.tsx
+++ b/apps/web/app/routes/joinorgapp.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-router";
 import { useEffect, useState } from "react";
 import { Button } from "~/components/Button";
+import { DropdownField, type DropdownOption } from "~/components/Dropdown";
 import { TextInput } from "~/components/TextInput";
 import { API_BASE_URL } from "~/config/constants";
 
@@ -51,11 +52,8 @@ type ActionSuccess = {
 type ActionError = { error: string };
 type ActionData = ActionSuccess | ActionError | undefined;
 
-const selectClassName =
-  "box-border flex h-10 w-full cursor-pointer appearance-none rounded-md border border-accent bg-transparent pl-4.5 pr-10 text-base text-foreground outline-none transition-shadow focus-visible:shadow-focus";
-
 /** Must match `USER_ROLES` in the API (`lead`, `researcher`, `trainee`, `admin`). */
-const INTENDED_ROLE_OPTIONS: { value: string; label: string }[] = [
+const INTENDED_ROLE_OPTIONS: DropdownOption[] = [
   { value: "", label: "No preference" },
   { value: "lead", label: "Lead" },
   { value: "researcher", label: "Researcher" },
@@ -143,8 +141,15 @@ export default function JoinOrgAppPage() {
   const [orgId, setOrgId] = useState("");
   const [unitId, setUnitId] = useState("");
 
-  const unitsResolved =
-    orgs.find((o) => o.id === orgId)?.units ?? [];
+  const orgOptions: DropdownOption[] = orgs.map((org) => ({
+    value: org.id,
+    label: org.name,
+  }));
+  const unitsResolved = orgs.find((o) => o.id === orgId)?.units ?? [];
+  const unitOptions: DropdownOption[] = unitsResolved.map((unit) => ({
+    value: unit.id,
+    label: unit.name,
+  }));
 
   useEffect(() => {
     setUnitId("");
@@ -172,7 +177,7 @@ export default function JoinOrgAppPage() {
                 <a
                   href={`/create-account?token=${encodeURIComponent(actionData.completeToken)}`}
                 >
-                  Open “set password” page
+                  Open "set password" page
                 </a>
               </Button>
             </div>
@@ -192,7 +197,7 @@ export default function JoinOrgAppPage() {
           Request to Join Organization
         </h2>
         <p>
-          Request access to your organization’s workspace. Once approved, you’ll
+          Request access to your organization's workspace. Once approved, you'll
           get a one-time magic link to register your account.
         </p>
       </div>
@@ -242,74 +247,47 @@ export default function JoinOrgAppPage() {
               value={email}
               onChange={(e) => setEmail(e.target.value)}
             />
-            <div className="flex flex-col gap-2 w-full">
-              <label htmlFor="intendedRole" className="text-label text-foreground">
-                Intended role (optional)
-              </label>
-              <select
-                id="intendedRole"
-                name="intendedRole"
-                className={selectClassName}
-                value={intendedRole}
-                onChange={(e) => setIntendedRole(e.target.value)}
-                aria-describedby="intended-role-hint"
-              >
-                {INTENDED_ROLE_OPTIONS.map((o) => (
-                  <option key={o.value || "none"} value={o.value}>
-                    {o.label}
-                  </option>
-                ))}
-              </select>
-            </div>
+            <DropdownField
+              id="intendedRole"
+              label="Intended role (optional)"
+              name="intendedRole"
+              value={intendedRole}
+              onValueChange={setIntendedRole}
+              options={INTENDED_ROLE_OPTIONS}
+            />
           </div>
         </div>
 
         <div className="flex w-full flex-col gap-4.5">
           <h3 className="font-semibold">Organization</h3>
           <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-2 w-full">
-              <label htmlFor="orgId" className="text-label text-foreground">
-                Organization
-              </label>
-              <select
-                id="orgId"
-                name="orgId"
-                className={selectClassName}
-                value={orgId}
-                onChange={(e) => setOrgId(e.target.value)}
-                required
-                disabled={orgs.length === 0}
-              >
-                <option value="">Select organization…</option>
-                {orgs.map((o) => (
-                  <option key={o.id} value={o.id}>
-                    {o.name}
-                  </option>
-                ))}
-              </select>
-            </div>
+            <DropdownField
+              id="orgId"
+              label="Organization"
+              name="orgId"
+              value={orgId}
+              onValueChange={setOrgId}
+              options={orgOptions}
+              placeholder="Select organization..."
+              required
+              disabled={orgOptions.length === 0}
+            />
 
             {orgId ? (
-              <div className="flex flex-col gap-2 w-full">
-                <label htmlFor="unitId" className="text-label text-foreground">
-                  Unit
-                </label>
-                <select
-                  id="unitId"
-                  name="unitId"
-                  className={selectClassName}
-                  value={unitId}
-                  onChange={(e) => setUnitId(e.target.value)}
-                  required
-                >
-                  <option value="">Select unit…</option>
-                  {unitsResolved.map((u) => (
-                    <option key={u.id} value={u.id}>
-                      {u.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <DropdownField
+                id="unitId"
+                label="Unit"
+                name="unitId"
+                value={unitId}
+                onValueChange={setUnitId}
+                options={unitOptions}
+                placeholder={
+                  unitOptions.length > 0 ? "Select unit..." : "No units available"
+                }
+                emptyText="No units available."
+                required
+                disabled={unitOptions.length === 0}
+              />
             ) : null}
           </div>
         </div>

--- a/apps/web/app/services/videos.ts
+++ b/apps/web/app/services/videos.ts
@@ -142,6 +142,30 @@ export const videoService = {
     return parseVideoUrlResponse(body);
   },
 
+  getThumbnail: async (
+    videoId: string,
+    timestamp: number,
+    signal?: AbortSignal,
+  ): Promise<Blob> => {
+    const params = new URLSearchParams({
+      timestamp: String(Math.max(0, timestamp)),
+    });
+
+    const res = await fetch(
+      `${API_BASE_URL}/api/v1/videos/${videoId}/thumbnail?${params.toString()}`,
+      {
+        headers: authHeaders(),
+        signal,
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch video thumbnail: ${res.status}`);
+    }
+
+    return res.blob();
+  },
+
   getVideo: async (videoId: string): Promise<VideoRecord> => {
     const res = await fetch(`${API_BASE_URL}/api/v1/videos/${videoId}`, {
       headers: authHeaders(),

--- a/apps/web/app/stores/useOverlayStore.ts
+++ b/apps/web/app/stores/useOverlayStore.ts
@@ -10,7 +10,7 @@ interface OverlayStore {
 }
 
 const DEFAULT_OVERLAYS: Record<StageOverlayKey, boolean> = {
-  gait: true,
+  gait: false,
   sway: false,
   points: false,
 };

--- a/apps/web/app/stores/useSessionStore.ts
+++ b/apps/web/app/stores/useSessionStore.ts
@@ -182,6 +182,13 @@ type SessionStore = {
   };
 };
 
+export function selectActiveView(state: SessionStore): View | null {
+  const activeSession = state.sessions.find(
+    (session) => session.id === state.activeSessionId,
+  );
+  return activeSession?.views.find((view) => view.id === state.activeViewId) ?? null;
+}
+
 /**
  * Manages the list of sessions, active session selection, and view creation.
  * Session metadata is fetched from and persisted to the backend API.

--- a/apps/web/app/stores/useSessionStore.ts
+++ b/apps/web/app/stores/useSessionStore.ts
@@ -2,6 +2,10 @@ import { create } from "zustand";
 import { type Session, type View } from "~/data/mock-session-data";
 import { sessionService } from "~/services/sessions";
 import { videoService } from "~/services/videos";
+import {
+  formatSessionDate,
+  normalizeSessionTime,
+} from "~/lib/session-date-time";
 
 const VIEW_TITLE_SAVE_DELAY_MS = 1_200;
 
@@ -67,14 +71,6 @@ function updateViewByVideoId(
 
 function isRemoteVideoUrl(url: string): boolean {
   return Boolean(url) && !url.startsWith("blob:");
-}
-
-/**
- * Converts an API session date (YYYY-MM-DD) to the display format (MM/DD/YYYY).
- */
-function formatSessionDate(isoDate: string): string {
-  const [year, month, day] = isoDate.split("-");
-  return `${month}/${day}/${year}`;
 }
 
 function resolveViewLabel(title: string, fileName: string): string {
@@ -170,6 +166,7 @@ type SessionStore = {
     addSession: (data: {
       patientId: string;
       date: Date;
+      time: string;
       media: MediaInput[];
     }) => Promise<string>;
     addView: (sessionId: string, media: MediaInput[]) => Promise<string>;
@@ -248,6 +245,7 @@ export const useSessionStore = create<SessionStore>((set, get) => {
             patientId: item.patientId,
             patientUuid: item.patientUuid,
             date: formatSessionDate(item.sessionDate),
+            time: normalizeSessionTime(item.sessionTime),
             notification: prev?.notification ?? false,
             views: prev?.views ?? [],
           };
@@ -335,10 +333,7 @@ export const useSessionStore = create<SessionStore>((set, get) => {
           String(data.date.getDate()).padStart(2, "0"),
         ].join("-");
 
-        const sessionTime = [
-          String(data.date.getHours()).padStart(2, "0"),
-          String(data.date.getMinutes()).padStart(2, "0"),
-        ].join(":");
+        const sessionTime = normalizeSessionTime(data.time);
 
         const result = await sessionService.create({
           patientId: data.patientId,
@@ -359,6 +354,7 @@ export const useSessionStore = create<SessionStore>((set, get) => {
           patientId: data.patientId,
           patientUuid: result.patientUuid,
           date: formatSessionDate(sessionDate),
+          time: sessionTime,
           notification: false,
           views,
         };


### PR DESCRIPTION
Improves session time UX, chapter thumbnails, and live keypoint polling

**Summary**

- add session time support throughout the frontend, including a time input flow and updated session metadata in the directory and header
- load chapter thumbnails from the API using each chapter timestamp so chapter cards feel more complete across generated and manual edits
- reduce `/keypoints/since` spam during pose estimation by waiting for more meaningful batches before polling again
- update progress indicators across sessions page while a video is being processed