### PR TITLE
thanh/fix

### DIFF
--- a/.github/workflows/build_and_push_web.yaml
+++ b/.github/workflows/build_and_push_web.yaml
@@ -73,7 +73,6 @@ jobs:
           build-args: |
             VITE_API_BASE_URL=https://mswa-gpu.cis240470.projects.jetstream-cloud.org
             VITE_API_KEY=your-api-key
-            VITE_UNIT_ID=a0f4aada-5c5e-427c-9864-e0c6fdca980e
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,8 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 # expose env var to build process
 ARG VITE_API_BASE_URL
 ARG VITE_API_KEY
-ARG VITE_UNIT_ID
 ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 ENV VITE_API_KEY=$VITE_API_KEY
-ENV VITE_UNIT_ID=$VITE_UNIT_ID
 # Run the build script (likely using Turborepo) to compile all apps.
 RUN pnpm build
 

--- a/apps/api/scripts/seed.ts
+++ b/apps/api/scripts/seed.ts
@@ -1,5 +1,3 @@
-import fs from "fs";
-import path from "path";
 import { exit } from "process";
 import db from "datasource";
 import { Org } from "@src/infra/db/entity/org/org";
@@ -10,56 +8,10 @@ import { UserIdentity } from "@src/infra/db/entity/user/identity";
 import { APPLICATION_STATUS, USER_ROLES } from "@config/enums";
 import type { Repository } from "typeorm";
 
-const SEED_ORG_NAME = "Test Org";
-const SEED_UNIT_NAME = "Test Unit";
+const SEED_ORG_NAME = "Casa Colina Hospital";
+const SEED_UNIT_NAME = "Research Unit";
 const SEED_USER_EMAIL = "test@example.com";
 const SEED_USER_PASSWORD = "testing124";
-
-/**
- * Upserts a KEY=VALUE line in an .env file.
- * If the key already exists, replaces its value (and removes duplicates).
- * If the key does not exist, appends it.
- */
-function upsertEnvVar(envPath: string, key: string, value: string) {
-  let content = "";
-  if (fs.existsSync(envPath)) {
-    content = fs.readFileSync(envPath, "utf-8");
-  }
-
-  const lines = content.split("\n");
-  const pattern = new RegExp(`^${key}=`);
-  const filtered = lines.filter((line) => !pattern.test(line));
-  filtered.push(`${key}=${value}`);
-  const result = filtered
-    .filter((l, i, arr) => {
-      return l.trim() !== "" || i < arr.length - 1;
-    })
-    .join("\n")
-    .replace(/\n*$/, "\n");
-
-  fs.writeFileSync(envPath, result);
-}
-
-/**
- * Writes the unit ID to both the API .env (TESTING_UNIT_ID)
- * and the web .env (VITE_UNIT_ID) so they stay in sync.
- */
-function syncUnitId(unitId: string) {
-  const apiEnvPath = path.resolve(__dirname, "../.env");
-  const webEnvPath = path.resolve(__dirname, "../../web/.env");
-
-  upsertEnvVar(apiEnvPath, "TESTING_UNIT_ID", unitId);
-  console.log(`  → API .env: TESTING_UNIT_ID=${unitId}`);
-
-  if (fs.existsSync(webEnvPath)) {
-    upsertEnvVar(webEnvPath, "VITE_UNIT_ID", unitId);
-    console.log(`  → Web .env: VITE_UNIT_ID=${unitId}`);
-  } else {
-    console.log(
-      `  → Web .env not found at ${webEnvPath}, skipping VITE_UNIT_ID sync`,
-    );
-  }
-}
 
 async function main() {
   try {
@@ -86,8 +38,6 @@ async function main() {
         `Seed tenant already exists (${SEED_ORG_NAME} / ${SEED_UNIT_NAME}).`,
       );
       await ensureTestUser(existingUnit, userRepository, userIdentityRepository);
-      console.log(`TESTING_UNIT_ID=${existingUnit.id}`);
-      syncUnitId(existingUnit.id);
       exit(0);
     }
 
@@ -120,8 +70,6 @@ async function main() {
 
     console.log(`Successfully seeded ${SEED_ORG_NAME} / ${SEED_UNIT_NAME}`);
     await ensureTestUser(unit, userRepository, userIdentityRepository);
-    console.log(`TESTING_UNIT_ID=${unit.id}`);
-    syncUnitId(unit.id);
     exit(0);
   } catch (e) {
     console.error(`Seed failed: ${e}`);

--- a/apps/api/src/routes/me/me.service.spec.ts
+++ b/apps/api/src/routes/me/me.service.spec.ts
@@ -45,20 +45,32 @@ describe('MeService', () => {
   describe('getProfile', () => {
     it('should return user profile', async () => {
       const userId = '12345';
-      const mockProfile = {
+      const dbUser = {
         id: userId,
-        name: 'Test User',
         email: 'test@example.com',
+        givenName: 'Test',
+        surname: 'User',
         phoneNumber: '1234567890',
         title: 'Mr.',
         role: 'admin',
         city: 'Test City',
+        unit: { id: 'unit-1' },
       };
-      userRepo.findOne = jest.fn().mockResolvedValue(mockProfile);
+      userRepo.findOne = jest.fn().mockResolvedValue(dbUser);
 
       const profile = await service.getProfile(userId);
 
-      expect(profile).toEqual(mockProfile);
+      expect(profile).toEqual({
+        id: userId,
+        email: 'test@example.com',
+        givenName: 'Test',
+        surname: 'User',
+        phoneNumber: '1234567890',
+        title: 'Mr.',
+        role: 'admin',
+        city: 'Test City',
+        unitId: 'unit-1',
+      });
     });
   });
 
@@ -66,25 +78,37 @@ describe('MeService', () => {
     it('should update and return user profile', async () => {
       const userId = '12345';
       const updateData = {
-        name: 'Updated User',
+        givenName: 'Updated',
+        surname: 'User',
         phoneNumber: '0987654321',
         title: 'Ms.',
         city: 'Updated City',
       };
-      const updatedProfile = {
+      const dbUser = {
         id: userId,
         email: 'test@example.com',
         ...updateData,
         role: 'admin',
+        unit: { id: 'unit-2' },
       };
 
       userRepo.update = jest.fn().mockResolvedValue(undefined);
-      userRepo.findOne = jest.fn().mockResolvedValue(updatedProfile);
+      userRepo.findOne = jest.fn().mockResolvedValue(dbUser);
 
       const profile = await service.updateProfile(userId, updateData);
 
       expect(userRepo.update).toHaveBeenCalledWith({ id: userId }, updateData);
-      expect(profile).toEqual(updatedProfile);
+      expect(profile).toEqual({
+        id: userId,
+        email: 'test@example.com',
+        givenName: 'Updated',
+        surname: 'User',
+        phoneNumber: '0987654321',
+        title: 'Ms.',
+        role: 'admin',
+        city: 'Updated City',
+        unitId: 'unit-2',
+      });
     });
   });
 

--- a/apps/api/src/routes/me/me.service.ts
+++ b/apps/api/src/routes/me/me.service.ts
@@ -5,6 +5,18 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Readable } from 'stream';
 import { Repository } from 'typeorm';
 
+type MeProfile = {
+  id: string;
+  email: string;
+  givenName: string;
+  surname: string;
+  role: User['role'];
+  title: string | null;
+  phoneNumber: string | null;
+  city: string | null;
+  unitId: string | null;
+};
+
 @Injectable()
 export class MeService {
   private logger = new Logger(MeService.name);
@@ -15,14 +27,31 @@ export class MeService {
     private readonly swiftService: SwiftService,
   ) {}
 
+  private toProfile(user: User | null): MeProfile | null {
+    if (!user) return null;
+
+    return {
+      id: user.id,
+      email: user.email,
+      givenName: user.givenName,
+      surname: user.surname,
+      role: user.role,
+      title: user.title,
+      phoneNumber: user.phoneNumber,
+      city: user.city,
+      unitId: user.unit?.id ?? null,
+    };
+  }
+
   /**
    * Get user profile by user ID
    * @param userId - ID of the user
    * @returns User profile or null if not found
    */
-  public async getProfile(userId: string): Promise<User | null> {
-    return await this.userRepository.findOne({
+  public async getProfile(userId: string): Promise<MeProfile | null> {
+    const user = await this.userRepository.findOne({
       where: { id: userId },
+      relations: { unit: true },
       select: {
         id: true,
         email: true,
@@ -32,8 +61,10 @@ export class MeService {
         title: true,
         phoneNumber: true,
         city: true,
+        unit: { id: true },
       },
     });
+    return this.toProfile(user);
   }
 
   /**
@@ -46,9 +77,9 @@ export class MeService {
   public async updateProfile(
     userId: string,
     updateData: Partial<User>,
-  ): Promise<User | null> {
+  ): Promise<MeProfile | null> {
     await this.userRepository.update({ id: userId }, updateData);
-    return this.getProfile(userId);
+    return await this.getProfile(userId);
   }
 
   /**

--- a/apps/api/test/invites.e2e-spec.ts
+++ b/apps/api/test/invites.e2e-spec.ts
@@ -3,17 +3,12 @@ import { TestingModule, Test } from '@nestjs/testing';
 import { AppModule } from '@src/routes/app.module';
 import request from 'supertest';
 import { App } from 'supertest/types';
-import dotenv from 'dotenv';
 import { USER_ROLES } from '@config/enums';
-dotenv.config();
 
 describe('UserController (e2e)', () => {
   let app: INestApplication<App>;
   let token: string;
   let unitId: string;
-  let userId: string = '';
-  const inviteeEmail = `invitee${Math.floor(Math.random() * 10000)}@example.com`;
-  let inviteToken: string;
 
   beforeEach(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -29,32 +24,42 @@ describe('UserController (e2e)', () => {
       .send({ email: 'test@example.com', password: 'testing124' })
       .expect(201);
     token = response.body.token;
-    unitId = process.env.TESTING_UNIT_ID || 'missing';
-    expect(unitId).not.toBe('missing');
-
-    const profileResponse = await request(app.getHttpServer())
-      .get(`/units/${unitId}/users`)
+    const resolvedUnitId = await request(app.getHttpServer())
+      .get('/me')
       .set({ authorization: `Bearer ${token}` })
       .expect(200)
-      .then((res) => res.body[0].id);
-    userId = profileResponse;
-    expect(userId).not.toBe('');
+      .then((res) => res.body.unitId as string | null);
+    expect(resolvedUnitId).toBeTruthy();
+    if (!resolvedUnitId) {
+      throw new Error('Expected /me to return unitId');
+    }
+    unitId = resolvedUnitId;
+
   });
 
   it('POST /units/:unitId/invites', async () => {
+    const inviteeEmail = `invitee${Math.floor(Math.random() * 10000)}@example.com`;
     return await request(app.getHttpServer())
       .post(`/units/${unitId}/invite`)
       .set({ authorization: `Bearer ${token}` })
       .send({ email: inviteeEmail, role: USER_ROLES.TRAINEE })
       .expect(201)
       .expect((res) => {
-        inviteToken = res.body.token;
+        const inviteToken = res.body.token as string;
         expect(inviteToken).toBeDefined();
         expect(inviteToken.length).toBeGreaterThan(0);
       });
   });
 
   it('POST /units/invites/accept/:inviteToken', async () => {
+    const inviteeEmail = `invitee${Math.floor(Math.random() * 10000)}@example.com`;
+    const inviteToken = await request(app.getHttpServer())
+      .post(`/units/${unitId}/invite`)
+      .set({ authorization: `Bearer ${token}` })
+      .send({ email: inviteeEmail, role: USER_ROLES.TRAINEE })
+      .expect(201)
+      .then((res) => res.body.token as string);
+
     return await request(app.getHttpServer())
       .post(`/units/invites/${inviteToken}`)
       .expect(201);

--- a/apps/api/test/users.e2e-spec.ts
+++ b/apps/api/test/users.e2e-spec.ts
@@ -3,8 +3,7 @@ import { TestingModule, Test } from '@nestjs/testing';
 import { AppModule } from '@src/routes/app.module';
 import request from 'supertest';
 import { App } from 'supertest/types';
-import dotenv from 'dotenv';
-dotenv.config();
+import { USER_ROLES } from '@config/enums';
 
 describe('UserController (e2e)', () => {
   let app: INestApplication<App>;
@@ -26,16 +25,19 @@ describe('UserController (e2e)', () => {
       .send({ email: 'test@example.com', password: 'testing124' })
       .expect(201);
     token = response.body.token;
-    unitId = process.env.TESTING_UNIT_ID || 'missing';
-    expect(unitId).not.toBe('missing');
-
-    const profileResponse = await request(app.getHttpServer())
-      .get(`/units/${unitId}/users`)
+    unitId = await request(app.getHttpServer())
+      .get('/me')
       .set({ authorization: `Bearer ${token}` })
       .expect(200)
-      .then((res) => res.body[0].id);
-    userId = profileResponse;
-    expect(userId).not.toBe('');
+      .then((res) => res.body.unitId as string | null);
+    expect(unitId).toBeTruthy();
+
+    userId = await request(app.getHttpServer())
+      .get('/me')
+      .set({ authorization: `Bearer ${token}` })
+      .expect(200)
+      .then((res) => res.body.id as string);
+    expect(userId).toBeTruthy();
   });
 
   it('GET /units/:unitId/users', async () => {
@@ -61,8 +63,34 @@ describe('UserController (e2e)', () => {
   });
 
   it('DELETE /units/:unitId/users/:userId', async () => {
+    const inviteeEmail = `delete-target-${Math.floor(
+      Math.random() * 1_000_000,
+    )}@example.com`;
+    const inviteToken = await request(app.getHttpServer())
+      .post(`/units/${unitId}/invite`)
+      .set({ authorization: `Bearer ${token}` })
+      .send({ email: inviteeEmail, role: USER_ROLES.TRAINEE })
+      .expect(201)
+      .then((res) => res.body.token as string);
+
+    await request(app.getHttpServer())
+      .post(`/units/invites/${inviteToken}`)
+      .expect(201);
+
+    const targetUserId = await request(app.getHttpServer())
+      .get(`/units/${unitId}/users`)
+      .set({ authorization: `Bearer ${token}` })
+      .expect(200)
+      .then((res) => {
+        const invitedUser = (res.body as Array<{ id: string; email: string }>).find(
+          (user) => user.email === inviteeEmail,
+        );
+        return invitedUser?.id ?? '';
+      });
+    expect(targetUserId).toBeTruthy();
+
     return await request(app.getHttpServer())
-      .delete(`/units/${unitId}/users/${userId}`)
+      .delete(`/units/${unitId}/users/${targetUserId}`)
       .set({ authorization: `Bearer ${token}` })
       .expect(200);
   });

--- a/apps/web/app/config/constants.ts
+++ b/apps/web/app/config/constants.ts
@@ -1,3 +1,2 @@
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "Missing API_BASE_URL";
 export const API_KEY = import.meta.env.VITE_API_KEY || "Missing API_KEY";
-export const UNIT_ID = import.meta.env.VITE_UNIT_ID || "Missing UNIT_ID";

--- a/apps/web/app/lib/auth.ts
+++ b/apps/web/app/lib/auth.ts
@@ -16,6 +16,7 @@ type User = {
   title: string | null;
   phoneNumber: string | null;
   city: string | null;
+  unitId: string | null;
 };
 
 /**

--- a/apps/web/app/services/sessions.ts
+++ b/apps/web/app/services/sessions.ts
@@ -1,4 +1,4 @@
-﻿import { API_BASE_URL, UNIT_ID } from "~/config/constants";
+﻿import { API_BASE_URL } from "~/config/constants";
 import { userAuthStore } from "~/lib/auth";
 
 /** Response shape returned by GET /api/v1/units/:unitId/sessions */
@@ -41,13 +41,24 @@ function authHeaders(): HeadersInit {
   };
 }
 
+async function resolveUnitId(): Promise<string> {
+  const { user, fetchUser } = userAuthStore.getState();
+  if (user?.unitId) return user.unitId;
+
+  const refreshedUser = await fetchUser();
+  if (refreshedUser?.unitId) return refreshedUser.unitId;
+
+  throw new Error("User is missing unit assignment.");
+}
+
 export const sessionService = {
   /**
    * GET /api/v1/units/:unitId/sessions
    * Fetches all sessions for the current unit.
    */
   getAll: async (): Promise<SessionListItem[]> => {
-    const res = await fetch(`${API_BASE_URL}/api/v1/units/${UNIT_ID}/sessions`, {
+    const unitId = await resolveUnitId();
+    const res = await fetch(`${API_BASE_URL}/api/v1/units/${unitId}/sessions`, {
       headers: authHeaders(),
     });
 
@@ -66,7 +77,8 @@ export const sessionService = {
    * @returns The created session's ID and resolved patient UUID
    */
   create: async (dto: CreateSessionDto): Promise<CreateSessionResponse> => {
-    const res = await fetch(`${API_BASE_URL}/api/v1/units/${UNIT_ID}/sessions`, {
+    const unitId = await resolveUnitId();
+    const res = await fetch(`${API_BASE_URL}/api/v1/units/${unitId}/sessions`, {
       method: "POST",
       headers: authHeaders(),
       body: JSON.stringify(dto),
@@ -89,8 +101,9 @@ export const sessionService = {
   getSessionVideos: async (
     sessionId: string,
   ): Promise<SessionVideoItem[]> => {
+    const unitId = await resolveUnitId();
     const res = await fetch(
-      `${API_BASE_URL}/api/v1/units/${UNIT_ID}/sessions/${sessionId}/videos`,
+      `${API_BASE_URL}/api/v1/units/${unitId}/sessions/${sessionId}/videos`,
       { headers: authHeaders() },
     );
 


### PR DESCRIPTION
# PR Checklist
- [x] Briefly describe your changes and include the issue number if it exists
- [x] Did you build your code? (`pnpm build`)
- [x] Does your code pass all tests (`pnpm test`)? Did you add new tests to for your changes? 
- [ ] Did you add any new environment variables? If so, did you notify an admin to update infisical?
- [ ] Did you document your changes? Do you need to update any of the `docs`?

- Removed unit-id env coupling from the app flow: frontend no longer uses VITE_UNIT_ID, and session APIs now resolve unitId from the authenticated user (/me).
- Updated backend profile response to include unitId and refactored MeService typing to use a clear MeProfile type.
- Simplified seeding so it still creates/reuses org, unit, and test user, but no longer writes unit IDs into .env files.